### PR TITLE
LZA-115: add repositories that we support

### DIFF
--- a/documentation/support/index.11tydata.js
+++ b/documentation/support/index.11tydata.js
@@ -1,0 +1,29 @@
+module.exports = {
+    actionRepos: [
+        {
+            name: "core-cloud-add-customer-action",
+            url: "https://www.github.com/UKHomeOffice/core-cloud-add-customer-action"
+        },
+        {
+            name: "match-label-action",
+            url: "https://www.github.com/UKHomeOffice/match-label-action"
+        },
+        {
+            name: "semver-calculate-action",
+            url: "https://www.github.com/UKHomeOffice/semver-calculate-action"
+        },
+        {
+            name: "semver-tag-action",
+            url: "https://www.github.com/UKHomeOffice/semver-tag-action"
+        },
+    ],
+    documentationRepos: [{
+        name: "core-cloud",
+        url: "https://www.github.com/UKHomeOffice/core-cloud"
+    },], configurationRepos: [
+        {
+            name: "core-cloud-github-config",
+            url: "https://www.github.com/UKHomeOffice/core-cloud-github-config"
+        },
+    ],
+}

--- a/documentation/support/index.11tydata.js
+++ b/documentation/support/index.11tydata.js
@@ -17,13 +17,16 @@ module.exports = {
             url: "https://www.github.com/UKHomeOffice/semver-tag-action"
         },
     ],
-    documentationRepos: [{
-        name: "core-cloud",
-        url: "https://www.github.com/UKHomeOffice/core-cloud"
-    },], configurationRepos: [
+    documentationRepos: [
+        {
+            name: "core-cloud",
+            url: "https://www.github.com/UKHomeOffice/core-cloud"
+        }
+    ],
+    configurationRepos: [
         {
             name: "core-cloud-github-config",
             url: "https://www.github.com/UKHomeOffice/core-cloud-github-config"
         },
-    ],
+    ]
 }

--- a/documentation/support/index.md
+++ b/documentation/support/index.md
@@ -1,0 +1,43 @@
+---
+layout: page.njk
+order: 6
+title: Support
+description: The different services that Core Cloud offer support for.
+excerpt: The different services that Core Cloud offer support for.
+tags:
+- homepage
+eleventyNavigation:
+  key: support
+  title: Support
+---
+
+### Repositories
+
+Core Cloud maintains and supports several public repositories, hosted on GitHub. 
+
+#### Actions
+
+<ul class="govuk-list">
+{% for item in actionRepos
+%}
+    <li><a class="govuk-link" href="{{ item.url }}">{{ item.name }}</a></li>
+{% endfor %}
+</ul>
+
+#### Configuration
+
+<ul class="govuk-list">
+{% for item in configurationRepos
+%}
+    <li><a class="govuk-link" href="{{ item.url }}">{{ item.name }}</a></li>
+{% endfor %}
+</ul>
+
+#### Documentation
+
+<ul class="govuk-list">
+{% for item in documentationRepos
+%}
+    <li><a class="govuk-link" href="{{ item.url }}">{{ item.name }}</a></li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
To ensure that we are working in the open, this change adds a generic support page that includes the repositories that are actively maintained by the team.