### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: core-cloud
+  annotations:
+    github.com/project-slug: UKHomeOffice/core-cloud
+spec:
+  type: other
+  lifecycle: unknown
+  owner: core-cloud-devops


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [Backstage App software catalog](https://backstage.cc-sandbox-ops-tooling.np.core.homeoffice.gov.uk).

After this pull request is merged, the component will become available.

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).